### PR TITLE
Adds numbered list helper

### DIFF
--- a/notion-to-md.js
+++ b/notion-to-md.js
@@ -104,8 +104,11 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
     if (type === "heading_3") parsedData = md.heading3(parsedData);
     if (type === "quote") parsedData = md.quote(parsedData);
 
-    if (type === "numbered_list_item" || type === "bulleted_list_item")
+    if (type === "bulleted_list_item")
       parsedData = md.bullet(parsedData);
+
+    if (type === "numbered_list_item")
+      parsedData = md.numbered(parsedData);
 
     if (type === "to_do") parsedData = md.todo(parsedData, block[type].checked);
 

--- a/utils/md.js
+++ b/utils/md.js
@@ -49,6 +49,10 @@ exports.bullet = (text) => {
   return `- ${text}`;
 };
 
+exports.numbered = (text) => {
+  return `1. ${text}`;
+};
+
 exports.todo = (text, checked) => {
   return checked ? `- [x] ${text}` : `- [ ] ${text}`;
 };


### PR DESCRIPTION
Markdown renders numbered lists correctly if you only use `1.`

Example can be seen here: https://gist.github.com/bitbonsai/1e69180bf8f8a82e83e67dd4b2951731