### PR TITLE
Fix leading and trailing space breaking annotation parsing

### DIFF
--- a/notion-to-md.js
+++ b/notion-to-md.js
@@ -125,13 +125,19 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
    * @param {object} annotations annotation object of a notion block
    */
   annotatePlainText(text, annotations) {
-    if (annotations.code) text = md.inlineCode(text);
-    if (annotations.bold) text = md.bold(text);
-    if (annotations.italic) text = md.italic(text);
-    if (annotations.strikethrough) text = md.strikethrough(text);
-    if (annotations.underline) text = md.underline(text);
+    const leading_space = text.match(/^\s*/)[0];
+    const trailing_space = text.match(/\s*$/)[0];
+    text = text.trim();
 
-    return text;
+    if (text !== '') {
+      if (annotations.code) text = md.inlineCode(text);
+      if (annotations.bold) text = md.bold(text);
+      if (annotations.italic) text = md.italic(text);
+      if (annotations.strikethrough) text = md.strikethrough(text);
+      if (annotations.underline) text = md.underline(text);
+    }
+
+    return leading_space + text + trailing_space;
   }
 }
 


### PR DESCRIPTION
When parsing annotated text, if the text has leading or trailing spaces, the parsed text doesn't render as expected in markdown. Here are some examples.

<img width="903" alt="Screen Shot 2021-12-12 at 10 19 21 PM" src="https://user-images.githubusercontent.com/43640229/145747731-0b7c1318-cb2c-4d9a-8c21-a896e2e166bb.png">

This change fixes this problem by shifting the leading and trailing spaces outside the parsed text.