### PR TITLE
feat: Add caption as alt to images

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -118,11 +118,12 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
     switch (type) {
       case "image": {
         let blockContent = block.image;
+        const image_caption_plain = blockContent.caption.map(item => item.plain_text).join('')
         const image_type = blockContent.type;
         if (image_type === "external")
-          return md.image("image", blockContent.external.url);
+          return md.image(image_caption_plain, blockContent.external.url);
         if (image_type === "file")
-          return md.image("image", blockContent.file.url);
+          return md.image(image_caption_plain, blockContent.file.url);
         break;
       }
       case "divider": {


### PR DESCRIPTION
Fix #11 

Example:

The next image block:
![](https://i.imgur.com/XX6wbTT.png)

turns into:

```md
![Image Description](https://g.com/image.png)
```