### PR TITLE
Add support for retrieving all children.

### DIFF
--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -14,7 +14,6 @@ export const getBlockChildren = async (
     do {
       const response = (await notionClient.blocks.children.list({
         start_cursor: start_cursor,
-        page_size: pageSize,
         block_id: block_id,
       })) as ListBlockChildrenResponse;
       result.push(...response.results);

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -8,27 +8,21 @@ export const getBlockChildren = async (
 ) => {
   try {
     let result = [];
-    let start_cursor;
-    let pageSize = 100;
-    for (let i = 0; i < totalPage; i++) {
-      // contain start_cursor
+    let has_more = true;
+    let pageCount = 0;
+    let start_cursor = undefined;
+    
+    do {
       const response = (await notionClient.blocks.children.list({
         start_cursor: start_cursor,
         page_size: pageSize,
         block_id: block_id,
       })) as ListBlockChildrenResponse;
-      let current = response.results;
-      // delete start_cursor
-      if (start_cursor) {
-        current.shift();
-      }
-      result.push(...current);
-      if (current.length < 100) {
-        break;
-      }
-      pageSize = 101;
-      start_cursor = current[current.length - 1].id;
-    }
+      result.push(...response.results);
+      
+      start_cursor = response?.next_cursor;
+      pageCount += 1;
+    } while(start_cursor != null && (totalPage == null || pageCount < totalPage))
     return result;
   } catch (e) {
     console.log(e);

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -8,7 +8,6 @@ export const getBlockChildren = async (
 ) => {
   try {
     let result = [];
-    let has_more = true;
     let pageCount = 0;
     let start_cursor = undefined;
     


### PR DESCRIPTION
Per https://github.com/souvikinator/notion-to-md/issues/13

Retrieves all children if `totalPage == null` 

Original Implementation [violated spec](https://developers.notion.com/reference/pagination): `start_cursor` should be treated as an opaque value, and `next_cursor` should be used to provide the next `start_cursor`. Deriving from the id may not be acceptable. Typically `has_more` can be used to determine whether there are more results; this implementation checks for the existence of `next_cursor` instead. 

