### PR TITLE
feat: add numbers to ordered list item

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -15,6 +15,8 @@ import { getBlockChildren } from "./utils/notion";
  */
 export class NotionToMarkdown {
   private notionClient: Client;
+  // TODO: better way to handle this?
+  private olCounter = 0;
 
   constructor(options: NotionToMarkdownOptions) {
     this.notionClient = options.notionClient;
@@ -292,9 +294,14 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
         break;
 
       case "bulleted_list_item":
-      case "numbered_list_item":
         {
           parsedData = md.bullet(parsedData);
+        }
+        break;
+
+        case "numbered_list_item":
+        {
+          parsedData = md.bullet(parsedData, ++this.olCounter);
         }
         break;
 

--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -57,8 +57,8 @@ export const callout = (text: string, icon?: CalloutIcon) => {
   return `> ${emoji ? emoji + ' ' : ''}${text.replace(/\n/g, "  \n>")}`;
 };
 
-export const bullet = (text: string) => {
-  return `- ${text}`;
+export const bullet = (text: string, count?: number) => {
+  return count ? `${count}. ${text}` : `- ${text}`;
 };
 
 export const todo = (text: string, checked: boolean) => {


### PR DESCRIPTION
This PR aims to fix #18 .

I have a created a class variable that would act as counter for ordered list.
The implementation of this is open for discussion.

It does not support nested <ol/> with numbers like
```md
1. A
2. B
  a.  Sub B
```