### PR TITLE
(patch) check for rich_text property

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -239,7 +239,7 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
         // In this case typescript is not able to index the types properly, hence ignoring the error
 
         // @ts-ignore
-        let blockContent = block[type].text || [];
+        let blockContent = block[type].text || block[type].rich_text || [];
         blockContent.map((content: Text) => {
           const annotations = content.annotations;
           let plain_text = content.plain_text;

--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -196,7 +196,7 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
               async (cell: any) =>
                 await this.blockToMarkdown({
                   type: "paragraph",
-                  paragraph: { text: cell },
+                  paragraph: { rich_text: cell },
                 } as ListBlockChildrenResponseResult)
             );
 


### PR DESCRIPTION
Fix for issue #23.

In order to keep support to prior versions of @notionhq/client@1.0.0, `rich_text` is added in the logical OR expression.

I've tested it in a personal project and it works OK.

<img width="350" alt="Screen Shot 2022-03-05 at 07 07 54" src="https://user-images.githubusercontent.com/510375/156870735-c31bf9ec-e271-4714-b72a-b523d76989d3.png">

Converts to:

```
# Heading 1

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla quis neque vel odio lobortis posuere nec sit amet erat. Morbi congue velit quis ante accumsan volutpat. Nam ornare enim eu metus consectetur facilisis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque ut convallis erat, eget egestas magna. Nunc non orci at ante placerat pretium in id justo. Morbi a mattis lacus. Nulla tempus, massa a cursus porta, risus leo varius urna, euismod tristique ante metus vitae lacus.

## Heading 2

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla quis neque vel odio lobortis posuere nec sit amet erat. Morbi congue velit quis ante accumsan volutpat. Nam ornare enim eu metus consectetur facilisis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque ut convallis erat, eget egestas magna. Nunc non orci at ante placerat pretium in id justo. Morbi a mattis lacus. Nulla tempus, massa a cursus porta, risus leo varius urna, euismod tristique ante metus vitae lacus.

### Heading 3

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla quis neque vel odio lobortis
```