### PR TITLE
Added support for numbered lists

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -1,3 +1,4 @@
+import { inspect } from "util";
 import { Client } from "@notionhq/client";
 import {
   Annotations,
@@ -121,7 +122,7 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
 
     let parsedData = "";
     const { type } = block;
-    // console.log({ block });
+    console.log(inspect(block, { colors: true, depth: null }));
 
     switch (type) {
       case "image":
@@ -325,9 +326,14 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
         break;
 
       case "bulleted_list_item":
-      case "numbered_list_item":
         {
           parsedData = md.bullet(parsedData);
+        }
+        break;
+
+      case "numbered_list_item":
+        {
+          parsedData = md.bullet(parsedData, block.numbered_list_item.number)
         }
         break;
 

--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -122,7 +122,7 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
 
     let parsedData = "";
     const { type } = block;
-    console.log(inspect(block, { colors: true, depth: null }));
+    // console.log(inspect(block, { colors: true, depth: null }));
 
     switch (type) {
       case "image":

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,18 @@
 import { ListBlockChildrenResponse } from "@notionhq/client/build/src/api-endpoints";
 import { Client } from "@notionhq/client";
 
+/* Notion's API types are ridiculously stupid */
+export type BlockAttributes = {
+  numbered_list_item?: {
+    number?: number;
+  };
+};
+
 export type ListBlockChildrenResponseResults =
-  ListBlockChildrenResponse["results"];
+  ListBlockChildrenResponse["results"] & BlockAttributes[];
 
 export type ListBlockChildrenResponseResult =
-  ListBlockChildrenResponseResults[0];
+  | ListBlockChildrenResponseResults[0] & BlockAttributes;
 
 export type TextRequest = string;
 
@@ -59,4 +66,8 @@ export type Text = {
   href: string | null;
 };
 
-export type CalloutIcon = { type: "emoji"; emoji?: string; } | { type: "external"; external?: {  url: string }; } | { type: "file"; file: { url: string; expiry_time: string; }; } | null;
+export type CalloutIcon =
+  | { type: "emoji"; emoji?: string }
+  | { type: "external"; external?: { url: string } }
+  | { type: "file"; file: { url: string; expiry_time: string } }
+  | null;

--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -58,8 +58,8 @@ export const callout = (text: string, icon?: CalloutIcon) => {
   return `> ${emoji ? emoji + " " : ""}${text.replace(/\n/g, "  \n>")}`;
 };
 
-export const bullet = (text: string) => {
-  return `- ${text}`;
+export const bullet = (text: string, count?: number) => {
+  return count ? `${count}. ${text}` : `- ${text}`;
 };
 
 export const todo = (text: string, checked: boolean) => {

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -1,5 +1,6 @@
 import { Client } from "@notionhq/client";
 import { ListBlockChildrenResponse } from "@notionhq/client/build/src/api-endpoints";
+import { ListBlockChildrenResponseResults } from "../types";
 
 export const getBlockChildren = async (
   notionClient: Client,
@@ -7,7 +8,7 @@ export const getBlockChildren = async (
   totalPage: number | null
 ) => {
   try {
-    let result = [];
+    let result: ListBlockChildrenResponseResults = [];
     let pageCount = 0;
     let start_cursor = undefined;
 
@@ -28,5 +29,18 @@ export const getBlockChildren = async (
   } catch (e) {
     console.log(e);
     return [];
+  }
+};
+
+export const processBlockChildren = (
+  blocks: ListBlockChildrenResponseResults
+) => {
+  let numberedListIndex = 0;
+
+  for (const block of blocks) {
+    if ("type" in block && block.type === "numbered_list_item") {
+      // add numbers
+      block.numbered_list_item.number = ++numberedListIndex;
+    }
   }
 };


### PR DESCRIPTION
This fixes issue #18 and even supports nested list items.

I solved this problem by introducing a new hook function that runs after each block's children is listed. I then "inject" a new property into the block object `number`, which just increments from 1 to max, and then in the rendering stage, use the property to render the numbered list bullets.

Result:

<img width="330" alt="Screenshot 2022-06-21 at 2 19 36 AM" src="https://user-images.githubusercontent.com/47694127/174659116-37dfcd42-e6ac-484c-ad8a-0892289f88c7.png">

<img width="335" alt="Screenshot 2022-06-21 at 2 19 53 AM" src="https://user-images.githubusercontent.com/47694127/174659143-e4b20736-b4be-4c0a-bcca-f05d9aad4e19.png">

🎉