### PR TITLE
Added support for numbered lists

### DIFF
--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -25,6 +25,8 @@ export const getBlockChildren = async (
       start_cursor != null &&
       (totalPage == null || pageCount < totalPage)
     );
+
+    processBlockChildren(result);
     return result;
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
This fixes issue #18 and even supports nested list items.

In PR #35, I forgot to call the function that takes the blocks and adds the index for the bullet point. This is now fixed.

I solved this problem by introducing a new hook function that runs after each block's children is listed. I then "inject" a new property into the block object `number`, which just increments from 1 to max, and then in the rendering stage, use the property to render the numbered list bullets.

Result:

<img width="330" alt="Screenshot 2022-06-21 at 2 19 36 AM" src="https://user-images.githubusercontent.com/47694127/174659116-37dfcd42-e6ac-484c-ad8a-0892289f88c7.png">

<img width="335" alt="Screenshot 2022-06-21 at 2 19 53 AM" src="https://user-images.githubusercontent.com/47694127/174659143-e4b20736-b4be-4c0a-bcca-f05d9aad4e19.png">

You can see it in production [here](https://raph.codes/blog/0515c4c1-7977-4163-85fb-c522f8fdf9a4#making-good-and-clean-pullrequests)