### PR TITLE
fix: handle empty titles in toggle

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -276,7 +276,7 @@ ${md.addTabSpace(mdBlocks.parent, nestingLevel)}
       case "toggle": {
         const { id, has_children } = block;
 
-        const toggle_summary = block.toggle.rich_text[0].plain_text;
+        const toggle_summary = block.toggle.rich_text[0]?.plain_text;
 
         // empty toggle
         if (!has_children) {

--- a/src/utils/md.spec.ts
+++ b/src/utils/md.spec.ts
@@ -14,6 +14,7 @@ import {
   quote,
   bullet,
   todo,
+  toggle,
   image,
 } from "./md";
 
@@ -113,3 +114,22 @@ describe("Image", () => {
     );
   });
 });
+
+describe("Toggle", () => {
+  const noSpaces = (text: string) => text.replace(/\s+/g, '')
+  test("displays content if toggle title is empty", () => {
+    expect(noSpaces(toggle(undefined, "content"))).toBe(
+      "content"
+    );
+  })
+  test("return empty string if title and content are empty", () => {
+    expect(noSpaces(toggle(undefined, undefined))).toBe(
+      ""
+    );
+  })
+  test("Displays toggle with <details> and <summary>", () => {
+    expect(noSpaces(toggle("title", "content"))).toBe(
+      "<details><summary>title</summary>content</details>"
+    );
+  })
+})

--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -85,7 +85,8 @@ export const divider = () => {
   return "---";
 };
 
-export const toggle = (summary: string, children?: string) => {
+export const toggle = (summary?: string, children?: string) => {
+  if(!summary) return children || ""
   return `<details>
   <summary>${summary}</summary>
 


### PR DESCRIPTION
The toggle function don't support empty toggles. 

Here the error on empty toggle:
```bash
// notion-to-md.js
                const toggle_summary = block.toggle.rich_text[0].plain_text;
TypeError: Cannot read properties of undefined (reading 'plain_text')
```

In this PR you will find: 

* Tests to fix the bug
* Changes in `utils/md#toggle`: 
    * accept undefined as title
    * returns content if title is undefined
    * returns empty string if title and content are empty