### PR TITLE
FIX: Ordered Lists Numbering Continue From Previous List

### DIFF
--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -45,5 +45,8 @@ export const modifyNumberedListObject = (
       // @ts-ignore
       block.numbered_list_item.number = ++numberedListIndex;
     }
+    else {
+      numberedListIndex = 0;
+    }
   }
 };


### PR DESCRIPTION
**Description**
A little fix for the ordered list numbering continuing from the previous ordered list. 

**Difference**
INPUT:
_List 1 in Notion:_
1\. apple
2\. banana
3\. orange

... other content from notion page

_List 2 in Notion:_
1\. car
2\. truck
3\. bike

OUTPUT BEFORE THESE CHANGES:
_List 1 in notion-to-md_
1\. apple
2\. banana
3\. orange

... other content from notion page

_List 2 in notion-to-md_
4\. apple
5\. banana
6\. orange


OUTPUT AFTER THESE CHANGES:
_List 1 in notion-to-md_
1\. apple
2\. banana
3\. orange

... other content from notion page

_List 2 in notion-to-md_
1\. apple
2\. banana
3\. orange