### PR TITLE
feat: Support sync or async function for custom transformer

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,4 +72,4 @@ export type CalloutIcon =
   | null;
 export type CustomTransformer = (
   block: ListBlockChildrenResponseResult
-) => Promise<string>;
+) => string | Promise<string>;


### PR DESCRIPTION
This avoids forcing clients to pass `async` function for custom transformers. 
This is not a breaking change since `await` works with sync and async functions.