### PR TITLE
Add comments, add blockIds to MarkdownBlock

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -1,15 +1,16 @@
-import { Client } from "@notionhq/client";
+import { Client } from '@notionhq/client';
+
 import {
   Annotations,
+  CustomTransformer,
   ListBlockChildrenResponseResult,
   ListBlockChildrenResponseResults,
   MdBlock,
-  Text,
   NotionToMarkdownOptions,
-  CustomTransformer,
-} from "./types";
-import * as md from "./utils/md";
-import { getBlockChildren } from "./utils/notion";
+  Text,
+} from './types';
+import * as md from './utils/md';
+import { getBlockChildren } from './utils/notion';
 
 /**
  * Converts a Notion page to Markdown.
@@ -118,17 +119,22 @@ export class NotionToMarkdown {
         block.type !== "toggle" &&
         block.type !== "callout"
       ) {
+        // Get children of this block.
         let child_blocks = await getBlockChildren(
           this.notionClient,
           block.id,
           totalPage
         );
+
+        // Push this block to mdBlocks.
         mdBlocks.push({
           type: block.type,
+          blockId: block.id,
           parent: await this.blockToMarkdown(block),
           children: [],
         });
 
+        // Recursively call blocksToMarkdown to get children of this block.
         let l = mdBlocks.length;
         await this.blocksToMarkdown(
           child_blocks,
@@ -139,8 +145,13 @@ export class NotionToMarkdown {
       }
       let tmp = await this.blockToMarkdown(block);
       // console.log(block);
-      // @ts-ignore
-      mdBlocks.push({ type: block.type, parent: tmp, children: [] });
+      mdBlocks.push({
+        // @ts-ignore
+        type: block.type,
+        blockId: block.id,
+        parent: tmp,
+        children: []
+      });
     }
     return mdBlocks;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,7 @@
-import { ListBlockChildrenResponse } from "@notionhq/client/build/src/api-endpoints";
-import { Client } from "@notionhq/client";
+import { Client } from '@notionhq/client';
+import {
+  ListBlockChildrenResponse,
+} from '@notionhq/client/build/src/api-endpoints';
 
 export type BlockAttributes = {
   numbered_list_item?: {
@@ -20,6 +22,7 @@ export interface NotionToMarkdownOptions {
 
 export type MdBlock = {
   type?: string;
+  blockId: string;
   parent: string;
   children: MdBlock[];
 };
@@ -31,25 +34,25 @@ export type Annotations = {
   underline: boolean;
   code: boolean;
   color:
-    | "default"
-    | "gray"
-    | "brown"
-    | "orange"
-    | "yellow"
-    | "green"
-    | "blue"
-    | "purple"
-    | "pink"
-    | "red"
-    | "gray_background"
-    | "brown_background"
-    | "orange_background"
-    | "yellow_background"
-    | "green_background"
-    | "blue_background"
-    | "purple_background"
-    | "pink_background"
-    | "red_background";
+  | "default"
+  | "gray"
+  | "brown"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "purple"
+  | "pink"
+  | "red"
+  | "gray_background"
+  | "brown_background"
+  | "orange_background"
+  | "yellow_background"
+  | "green_background"
+  | "blue_background"
+  | "purple_background"
+  | "pink_background"
+  | "red_background";
 };
 
 export type Text = {


### PR DESCRIPTION
Hi awesome library!

While working on a project of mine, I realized I needed to be able to trace down the block ids corresponding to a given markdown object.

I added a quick little addition to the MarkdownBlock idea to do this.

Let me know if there's anything else this needs!

(PS: Sorry about auto-formatting, editor-based)