### PR TITLE
Add default return value in setCustomTransformer callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Convert notion pages, block and list of blocks to markdown (supports nesting) us
 - [x] nested blocks
 - [x] embeds, bookmarks, videos, files (converted to links)
 - [x] Simple tables
-- [x] toggle 
+- [x] toggle
 - [x] divider
 - [x] equation block (converted to code blocks)
 - [x] convert returned markdown object to string (`toMarkdownString()`)
@@ -198,24 +198,41 @@ console.log(result);
 ```
 
 ## Custom Transformers
+
 You can define your own custom transformer for a notion type, to parse and return your own string.
 `setCustomTransformer(type, func)` will overload the parsing for the giving type.
 
-```js
+```ts
 const { NotionToMarkdown } = require("notion-to-md");
 const n2m = new NotionToMarkdown({ notionClient: notion });
-n2m.setCustomTransformer('embed', async (block) => {
-  const {embed} = block as any;
-  if (!embed?.url) return '';
+n2m.setCustomTransformer("embed", async (block) => {
+  const { embed } = block as any;
+  if (!embed?.url) return "";
   return `<figure>
   <iframe src="${embed?.url}"></iframe>
   <figcaption>${await n2m.blockToMarkdown(embed?.caption)}</figcaption>
 </figure>`;
 });
 const result = n2m.blockToMarkdown(block);
-// Result will now parse the `embed` type with your custom function. 
+// Result will now parse the `embed` type with your custom function.
 ```
+
 **Note** Be aware that `setCustomTransformer` will take only the last function for the given type. You can't set two different transforms for the same type.
+
+You can also use the default parsing by returning `false` in your custom transformer.
+
+```ts
+// ...
+n2m.setCustomTransformer("embed", async (block) => {
+  const { embed } = block as any;
+  if (embed?.url?.includes("myspecialurl.com")) {
+    return `...`; // some special rendering
+  }
+  return false; // use default behavior
+});
+const result = n2m.blockToMarkdown(block);
+// Result will now only use custom parser if the embed url matches a specific url
+```
 
 ## Contribution
 
@@ -227,7 +244,6 @@ Please make sure to update tests as appropriate.
 <a href="https://github.com/souvikinator/notion-to-md/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=souvikinator/notion-to-md" />
 </a>
-
 
 ## License
 

--- a/src/notion-to-md.spec.ts
+++ b/src/notion-to-md.spec.ts
@@ -1,30 +1,68 @@
-import  { NotionToMarkdown } from './notion-to-md';
+import { NotionToMarkdown } from "./notion-to-md";
 
 describe("setCustomTransformer", () => {
-
   test("blockToMarkdown sends parsing block to customTransformer", () => {
-    const customTransformerMock =jest.fn()
-    const n2m = new NotionToMarkdown({notionClient: {} as any})
-    n2m.setCustomTransformer("test", customTransformerMock)
+    const customTransformerMock = jest.fn();
+    const n2m = new NotionToMarkdown({ notionClient: {} as any });
+    n2m.setCustomTransformer("test", customTransformerMock);
     n2m.blockToMarkdown({
-      id: "test", name: "test", type: "test", test: {"foo": "bar"}
-    } as any)
-    expect(customTransformerMock).toHaveBeenCalledWith(expect.objectContaining({
-      type: "test", test: {"foo": "bar"}
-    }))
-  })
+      id: "test",
+      name: "test",
+      type: "test",
+      test: { foo: "bar" },
+    } as any);
+    expect(customTransformerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "test",
+        test: { foo: "bar" },
+      })
+    );
+  });
   test("supports only one customTransformer per type ", () => {
-    const customTransformerMock1 =jest.fn()
-    const customTransformerMock2 = jest.fn()
-    const n2m = new NotionToMarkdown({notionClient: {} as any})
-    n2m.setCustomTransformer("test", customTransformerMock1)
-    n2m.setCustomTransformer("test", customTransformerMock2)
+    const customTransformerMock1 = jest.fn();
+    const customTransformerMock2 = jest.fn();
+    const n2m = new NotionToMarkdown({ notionClient: {} as any });
+    n2m.setCustomTransformer("test", customTransformerMock1);
+    n2m.setCustomTransformer("test", customTransformerMock2);
     n2m.blockToMarkdown({
-      id: "test", name: "test", type: "test", test: {"foo": "bar"}
-    } as any)
-    expect(customTransformerMock1).not.toHaveBeenCalled()
-    expect(customTransformerMock2).toHaveBeenCalled()
-  })
+      id: "test",
+      name: "test",
+      type: "test",
+      test: { foo: "bar" },
+    } as any);
+    expect(customTransformerMock1).not.toHaveBeenCalled();
+    expect(customTransformerMock2).toHaveBeenCalled();
+  });
 
+  test("customTransformer implementation works", async () => {
+    const customTransformerMock = jest.fn();
+    customTransformerMock.mockImplementation(async () => {
+      return "hello";
+    });
+    const n2m = new NotionToMarkdown({ notionClient: {} as any });
+    n2m.setCustomTransformer("divider", customTransformerMock);
+    const md = await n2m.blockToMarkdown({
+      id: "test",
+      type: "divider",
+      divider: {},
+      object: "block",
+    });
+    expect(md).toBe("hello");
+  });
 
-})
+  test("customTransformer default implementation works", async () => {
+    const customTransformerMock = jest.fn();
+    customTransformerMock.mockImplementation(async () => {
+      return false;
+    });
+    const n2m = new NotionToMarkdown({ notionClient: {} as any });
+    n2m.setCustomTransformer("divider", customTransformerMock);
+    const md = await n2m.blockToMarkdown({
+      id: "test",
+      type: "divider",
+      divider: {},
+      object: "block",
+    });
+    expect(md).toBe("---");
+  });
+});

--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -155,8 +155,11 @@ export class NotionToMarkdown {
 
     let parsedData = "";
     const { type } = block;
-    if (type in this.customTransformers && !!this.customTransformers[type])
-      return await this.customTransformers[type](block);
+    if (type in this.customTransformers && !!this.customTransformers[type]) {
+      const customTransformerValue = await this.customTransformers[type](block);
+      if (!!customTransformerValue || customTransformerValue === "")
+        return customTransformerValue;
+    }
 
     switch (type) {
       case "image":


### PR DESCRIPTION
## Context
- want to support returning default parsed value from custom transformers
- this PR adds support for returning default parsed values if the custom transformer returns `false`
- resolves #50

## Changes
- do not return value if custom transformer returns `false` 

## Test Plan
- added unit tests to test actual implementation of custom transformers