### PR TITLE
feat: add markdown for equation and inline equations

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -7,7 +7,6 @@ import {
   ListBlockChildrenResponseResults,
   MdBlock,
   NotionToMarkdownOptions,
-  CustomTransformer,
   Equation,
   Text,
 } from './types';

--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -7,6 +7,7 @@ import {
   Text,
   NotionToMarkdownOptions,
   CustomTransformer,
+  Equation,
 } from "./types";
 import * as md from "./utils/md";
 import { getBlockChildren } from "./utils/notion";
@@ -177,8 +178,8 @@ export class NotionToMarkdown {
         return md.divider();
       }
 
-      case "equation": {
-        return md.codeBlock(block.equation.expression);
+      case 'equation': {
+        return md.equation(block.equation.expression);
       }
 
       case "video":
@@ -357,7 +358,12 @@ export class NotionToMarkdown {
         // In this case typescript is not able to index the types properly, hence ignoring the error
         // @ts-ignore
         let blockContent = block[type].text || block[type].rich_text || [];
-        blockContent.map((content: Text) => {
+        blockContent.map((content: Text | Equation) => {
+          if (content.type === 'equation') {
+            parsedData += md.inlineEquation(content.equation.expression);
+            return;
+          }
+          
           const annotations = content.annotations;
           let plain_text = content.plain_text;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,23 @@ export type Text = {
   href: string | null;
 };
 
+export type Equation = {
+  type: "equation";
+  equation: { 
+    expression: string;
+  },
+  annotations: {
+    bold: false;
+    italic: false;
+    strikethrough: false;
+    underline: false;
+    code: false;
+    color: "default";
+  },
+  plain_text: string;
+  href: null;
+};
+
 export type CalloutIcon =
   | { type: "emoji"; emoji?: string }
   | { type: "external"; external?: { url: string } }

--- a/src/utils/md.spec.ts
+++ b/src/utils/md.spec.ts
@@ -16,6 +16,8 @@ import {
   todo,
   toggle,
   image,
+  inlineEquation,
+  equation,
 } from "./md";
 
 describe("Callout", () => {
@@ -67,6 +69,16 @@ simple text
 \`\`\``.trim()
     );
   });
+  test("Inline Equation", () => {
+    expect(inlineEquation("E = mc^2")).toBe("$E = mc^2$");
+  });
+  test("Equation Block", () => {
+    expect(equation("E = mc^2")).toBe(
+      `$$
+E = mc^2
+$$`.trim()
+    );
+  });  
   test("Bold", () => {
     expect(bold("simple text")).toBe("**simple text**");
   });

--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -5,6 +5,10 @@ export const inlineCode = (text: string) => {
   return `\`${text}\``;
 };
 
+export const inlineEquation = (text: string) => {
+  return `$${text}$`;
+};
+
 export const bold = (text: string) => {
   return `**${text}**`;
 };
@@ -31,6 +35,12 @@ export const codeBlock = (text: string, language?: string) => {
   return `\`\`\`${language}
 ${text}
 \`\`\``;
+};
+
+export const equation = (text: string) => {
+  return `$$
+${text}
+$$`;
 };
 
 export const heading1 = (text: string) => {


### PR DESCRIPTION
This PR implements markdown formatting of block equations and inline equations.

Inline equations are enclosed between single dollar `$` symbols and block equations are enclosed by double dollar `$$` symbols:

```md
$inline$

$$
block
$$
```
This is supported by [remark-math](https://github.com/remarkjs/remark-math/tree/main/packages/remark-math#use) from unified.js and by [GitHub Markdown](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions).