### PR TITLE
feat: Add caption to code block.

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -453,7 +453,7 @@ export class NotionToMarkdown {
     switch (type) {
       case "code":
         {
-          parsedData = md.codeBlock(parsedData, block[type].language);
+          parsedData = md.codeBlock(parsedData, block[type].language, block[type].caption[0]?.plain_text);
         }
         break;
 

--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -31,10 +31,10 @@ export const link = (text: string, href: string) => {
   return `[${text}](${href})`;
 };
 
-export const codeBlock = (text: string, language?: string) => {
+export const codeBlock = (text: string, language?: string, caption?: string | undefined) => {
   if (language === "plain text") language = "text";
 
-  return `\`\`\`${language}
+  return `\`\`\`${language} ${caption ?? ""}
 ${text}
 \`\`\``;
 };


### PR DESCRIPTION
Adding the caption to the code block as [it's supported in the notion api ](https://developers.notion.com/changelog/caption-property-is-now-supported-in-code-block-type) and it's useful!