### PR TITLE
fix: config for separateChildPage now correctly on NotionToMarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,15 @@ const fs = require('fs');
 
 const notion = new Client({
   auth: "your integration token",
-  config:{
-     separateChildPage:true, // default: false
-  }
 });
 
 // passing notion client to the option
-const n2m = new NotionToMarkdown({ notionClient: notion });
+const n2m = new NotionToMarkdown({ 
+  notionClient: notion,
+    config:{
+     separateChildPage:true, // default: false
+  }
+ });
 
 (async () => {
   const mdblocks = await n2m.pageToMarkdown("target_page_id");


### PR DESCRIPTION
This is correcting location of config object in Readme

It was added incorrectly  as property of Notion Client. I have moved it to show as property on NotionToMarkdown