### PR TITLE
Adding a dummy `heading_4` type

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -426,6 +426,7 @@ export class NotionToMarkdown {
       // "heading_1"
       // "heading_2"
       // "heading_3"
+      // "heading_4" (dummy)
       // "bulleted_list_item"
       // "numbered_list_item"
       // "quote"
@@ -487,6 +488,12 @@ export class NotionToMarkdown {
       case "heading_3":
         {
           parsedData = md.heading3(parsedData);
+        }
+        break;
+
+      case "heading_4":
+        {
+          parsedData = md.heading4(parsedData);
         }
         break;
 

--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -57,6 +57,10 @@ export const heading3 = (text: string) => {
   return `### ${text}`;
 };
 
+export const heading4 = (text: string) => {
+  return `#### ${text}`;
+};
+
 export const quote = (text: string) => {
   // the replace is done to handle multiple lines
   return `> ${text.replace(/\n/g, "  \n> ")}`;


### PR DESCRIPTION
Hi there,

I'm submitting this Pull Request to propose a non-intrusive solution aimed at static website generators like Docusaurus, which typically reserve H1 headings (#) for page titles, making them unusable for other purposes within the content. This is quite annoying as Notion only has 3 types.

<img width="730" alt="image" src="https://github.com/souvikinator/notion-to-md/assets/59659182/287212f8-8bed-4260-92ee-12661f8e5605">

The changes I've implemented provide a workaround that allows any stack built on top of `notion-to-md` the possibility to increment heading levels by 1 if needed before calling notion-to-md, without the necessity for extensive modifications to the codebase. 

@souvikinator 