### PR TITLE
Skip unsupported block type.

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -201,7 +201,7 @@ export class NotionToMarkdown {
       let block: ListBlockChildrenResponseResult = blocks[i];
 
       // @ts-ignore
-      if (block.type === "child_page" && !this.config.parseChildPages) {
+      if (block.type === 'unsupported' || (block.type === "child_page" && !this.config.parseChildPages)) {
         continue;
       }
 


### PR DESCRIPTION
blocksToMarkdown fails for unsupported block types.

For example: `Block type ai_block is not supported via the API for your bot type.`

<img width="776" alt="image" src="https://github.com/souvikinator/notion-to-md/assets/37832854/1890fa34-5a94-4e04-b1ef-85921c7f0214">
