### PR TITLE
Fix regex callout heading

### DIFF
--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -71,7 +71,7 @@ export const callout = (text: string, icon?: CalloutIcon) => {
   // the replace is done to handle multiple lines
   const formattedText = text.replace(/\n/g, "  \n> ");
   const formattedEmoji = emoji ? emoji + " " : "";
-  const headingMatch = text.match(/^(#{1,6})\s+(.*)/);
+  const headingMatch = formattedText.match(/^(#{1,6})\s+([.*\s\S]+)/);
   if (headingMatch) {
     const headingLevel = headingMatch[1].length;
     const headingContent = headingMatch[2];


### PR DESCRIPTION
The regex had 2 issues:
- taking the non formatted text
- not taking into account whitespaces and line breaks which would not display content following the first block/line