### PR TITLE
matching interface changes in notion package

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,6 +94,7 @@ export type Annotations = {
     | "purple"
     | "pink"
     | "red"
+    | "default_background"
     | "gray_background"
     | "brown_background"
     | "orange_background"
@@ -139,6 +140,7 @@ export type CalloutIcon =
   | { type: "emoji"; emoji?: string }
   | { type: "external"; external?: { url: string } }
   | { type: "file"; file: { url: string; expiry_time: string } }
+  | { type: "custom_emoji"; custom_emoji: { id: string; name: string; url: string } }
   | null;
 
 export type CustomTransformer = (


### PR DESCRIPTION
Yesterday Notion changed some type definitions, making them incompatible with the types defined in by notion-to-md. Those changes are [here](https://github.com/makenotion/notion-sdk-js/blob/eed58030649895b95ab9b97e2959f77bab19cd62/src/api-endpoints.ts#L759) and [here](https://github.com/makenotion/notion-sdk-js/blob/eed58030649895b95ab9b97e2959f77bab19cd62/src/api-endpoints.ts#L4683).

I went looking for a bit of robustness so this doesn't get broken by arbitrary changes again from Notion in the future. Looks like another package [notion types](https://www.npmjs.com/package/notion-types) would keep up with changes like this (albeit less precisely than the aliases defined here. Unless the maintainers are averse to adding additional packages I'll see if this could be a more permanent solution than the hotfix here.