### PR TITLE
fix: handle undefined parent when quote has paragraph content

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -142,7 +142,7 @@ export class NotionToMarkdown {
             nestingLevel,
           );
 
-          const formattedContent = mdstr.parent
+          const formattedContent = (mdstr.parent ?? mdstr[pageIdentifier])
             .split("\n")
             .map((line) => (line.trim() ? `> ${line}` : ">"))
             .join("\n")


### PR DESCRIPTION
Fix for https://github.com/souvikinator/notion-to-md/issues/137