### PR TITLE
Fix for newlines in table cells

### DIFF
--- a/src/notion-to-md.ts
+++ b/src/notion-to-md.ts
@@ -446,7 +446,7 @@ export class NotionToMarkdown {
                 } as ListBlockChildrenResponseResult),
             );
 
-            const cellStringArr = await Promise.all(cellStringPromise);
+            const cellStringArr = (await Promise.all(cellStringPromise)).map((s) => s.replace(/\n/g, '<br>'));
             tableArr.push(cellStringArr);
           });
           await Promise.all(rowsPromise || []);


### PR DESCRIPTION
Newlines in table cells broke structure of table, this should be fix. (and not sure if there is some better way than `<br>`)