### PR TITLE
Remove leading whitespace in toggle transformer

### DIFF
--- a/src/plugins/renderer/mdx/transformers/blocks.ts
+++ b/src/plugins/renderer/mdx/transformers/blocks.ts
@@ -286,9 +286,9 @@ export const blockTransformers: Partial<
       // If no children, return just a basic toggle
       if (!block.children?.length) {
         return `<details>
-  <summary>
-  ${text}
-  </summary>
+<summary>
+${text}
+</summary>
 </details>\n\n`;
       }
 
@@ -298,11 +298,11 @@ export const blockTransformers: Partial<
       );
 
       return `<details>
-  <summary>
-  ${text}
-  </summary>
+<summary>
+${text}
+</summary>
 
-  ${childrenContent.join('\n')}
+${childrenContent.join('\n')}
 
 </details>\n\n`;
     },


### PR DESCRIPTION
In the `toggle` transformer, there is whitespace before the child content in the block. This is an issue when the child block is a `code` block, as it causes the first line of the code block `( ```language )` to be indented, causing indentation errors/inconsistencies in the actual code/text inside the block.

I have done some (basic) testing, and everything appears to be rendering correctly. 